### PR TITLE
🐛 Hotfix: JavaScriptナビゲーションエラーを修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -389,22 +389,6 @@
       const next = valid.includes(hash) ? hash : '#/dashboard';
       uiState.route = next;
       
-      // bodyの背景色をルートに応じて変更
-      // body背景色は常にダークテーマ
-      // const bgColors = {
-        '#/dashboard': 'bg-gray-800',
-        '#/today': 'bg-gray-800',
-        '#/exercise': 'bg-gray-800',
-        '#/set': 'bg-gray-800',
-        '#/history': 'bg-gray-800',
-        '#/settings': 'bg-gray-800'
-      };
-      
-      const body = document.body;
-      // 既存の背景色クラスを削除
-      Object.values(bgColors).forEach(cls => body.classList.remove(cls));
-      // 新しい背景色クラスを追加
-      body.classList.add(bgColors[next]);
       
       document.querySelectorAll('.route-view').forEach(section => {
         section.classList.toggle('hidden', section.getAttribute('data-route') !== next);


### PR DESCRIPTION
## 🐛 問題

初期画面でタイトルしか表示されず、ボタンなどが動作しない状態でした。

## 🔍 原因

`handleNavigation`関数内で、コメントアウトされた`bgColors`オブジェクトを参照していたため、JavaScriptエラーが発生していました。

## ✅ 修正内容

- 不要な`bgColors`参照コードを削除
- body背景色は常にダークテーマ(#0A0A0A)で固定
- ナビゲーションとレンダリング機能を正常化

## 🧪 テスト

- ✅ JavaScriptエラーが解消
- ✅ ダッシュボードが正常に表示
- ✅ ルーティングが正常に動作
- ✅ ダークテーマが維持される